### PR TITLE
Netlist: Refactor

### DIFF
--- a/faebryk/exporters/netlist/kicad/netlist_kicad.py
+++ b/faebryk/exporters/netlist/kicad/netlist_kicad.py
@@ -236,33 +236,33 @@ def from_faebryk_t2_netlist(netlist):
         return out_unique
 
 
-    pre_comps = unique([vertex["comp"] for net in netlist for vertex in net["vertices"]])
+    pre_comps = unique([vertex.component for net in netlist for vertex in net.vertices])
 
     comps = [
         _defaulted_comp(
-            ref=comp["name"],
-            value=comp["value"],
-            footprint=kicad_fp(comp["properties"]["footprint"]),
+            ref=comp.name,
+            value=comp.value,
+            footprint=kicad_fp(comp.properties["footprint"]),
             tstamp=next(tstamp),
         )
         for comp in #pre_comps
-            sorted(pre_comps, key=lambda comp: comp["name"])
+            sorted(pre_comps, key=lambda comp: comp.name)
             # sort because tstamp determined by pos
     ]
 
     nets = [
         _gen_net(
             code=next(net_code),
-            name=net["properties"].get("name", gen_net_name(net)),
+            name=net.properties.get("name", gen_net_name(net)),
             nodes=[
                 _gen_node(
-                    ref=vertex["comp"]["name"],
-                    pin=vertex["pin"],
+                    ref=vertex.component.name,
+                    pin=vertex.pin,
                 ) for vertex in #net["vertices"]
-                    sorted(net["vertices"], key=lambda x: x["comp"]["name"])
+                    sorted(net.vertices, key=lambda vert: vert.component.name)
             ]
         ) for net in #netlist
-            sorted(netlist, key=lambda net: net["properties"].get("name"))
+            sorted(netlist, key=lambda net: net.properties.get("name"))
             # sort because code determined by pos
     ]
 

--- a/faebryk/exporters/netlist/netlist.py
+++ b/faebryk/exporters/netlist/netlist.py
@@ -9,7 +9,7 @@ from faebryk.libs.exceptions import FaebrykException
 # 0. netlist = graph
 
 #TODO add name precendence
-# t1 is basically a reduced version of the grap
+# t1 is basically a reduced version of the graph
 # t1_netlist = [
 #     {name, value, properties, real,
 #       neighbors={pin: [{&vertex, pin}]},

--- a/test/exporters/netlist/kicad/test_netlist_kicad.py
+++ b/test/exporters/netlist/kicad/test_netlist_kicad.py
@@ -118,56 +118,57 @@ def test_netlist_t1():
 
 def test_netlist_t2():
     from faebryk.exporters.netlist.kicad.netlist_kicad import from_faebryk_t2_netlist
+    from faebryk.exporters.netlist import Net, Vertex, Component
 
     # t2_netlist = [(properties, vertices=[comp=(name, value, properties), pin)])]
 
-    resistor1 = {
-        "name": "R1",
-        "value": "R",
-        "properties": {
+    resistor1 = Component(
+        name = "R1",
+        value = "R",
+        properties = {
             "footprint": "Resistor_SMD:R_0805_2012Metric",
         },
-    }
+    )
 
-    resistor2 = {
-        "name": "R2",
-        "value": "R",
-        "properties": {
+    resistor2 = Component(
+        name = "R2",
+        value = "R",
+        properties = {
             "footprint": "Resistor_SMD:R_0805_2012Metric",
         },
-    }
+    )
 
     netlist = [
-        {
-            "properties": {
+        Net(
+            properties = {
                 "name": "GND",
             },
-            "vertices": [
-                {
-                    "comp": resistor1,
-                    "pin": 2
-                },
-                {
-                    "comp": resistor2,
-                    "pin": 2
-                },
+            vertices = [
+                Vertex(
+                    component = resistor1,
+                    pin = 2,
+                ),
+                Vertex(
+                    component = resistor2,
+                    pin = 2,
+                ),
             ],
-        },
-        {
-            "properties": {
+        ),
+        Net(
+            properties = {
                 "name": "+3V3",
             },
-            "vertices": [
-                {
-                    "comp": resistor1,
-                    "pin": 1
-                },
-                {
-                    "comp": resistor2,
-                    "pin": 1
-                },
+            vertices = [
+                Vertex(
+                    component = resistor1,
+                    pin = 1,
+                ),
+                Vertex(
+                    component = resistor2,
+                    pin = 1,
+                ),
             ],
-        },
+        ),
     ]
     #print("T2 netlist:", netlist)
 


### PR DESCRIPTION
Instead of using dicts and tuples introduce a few data classes with
equivalent fields. These fields must exists, so nothing is lost
by not using dicts/tuples.
The class definitions also serve to document the structure of the
netlist.