### PR TITLE
Core: Add backref in traits to their object

### DIFF
--- a/faebryk/library/library/components.py
+++ b/faebryk/library/library/components.py
@@ -27,16 +27,16 @@ class Resistor(Component):
                 r = Resistor.__new__(Resistor)
                 r._setup_resistance(resistance)
                 r.interfaces = interfaces
-                r.get_trait(has_interfaces).set_interface_comp(r)
+                r.get_trait(has_interfaces).set_interface_comp()
 
                 return r
 
-        self.add_trait(has_interfaces_list(self))
+        self.add_trait(has_interfaces_list())
         self.add_trait(_contructable_from_component())
 
     def _setup_interfaces(self):
         self.interfaces = times(2, Electrical)
-        self.get_trait(has_interfaces).set_interface_comp(self)
+        self.get_trait(has_interfaces).set_interface_comp()
 
     def __new__(cls, *args, **kwargs):
         self = super().__new__(cls)
@@ -86,7 +86,7 @@ class LED(Component):
     def _setup_interfaces(self):
         self.anode = Electrical()
         self.cathode = Electrical()
-        self.get_trait(has_interfaces).set_interface_comp(self)
+        self.get_trait(has_interfaces).set_interface_comp()
 
     def __new__(cls):
         self = super().__new__(cls)
@@ -117,11 +117,11 @@ class LED(Component):
 class Switch(Component):
     def _setup_traits(self):
         self.add_trait(has_defined_type_description("SW"))
-        self.add_trait(has_interfaces_list(self))
+        self.add_trait(has_interfaces_list())
 
     def _setup_interfaces(self):
         self.interfaces = times(2, Electrical)
-        self.get_trait(has_interfaces).set_interface_comp(self)
+        self.get_trait(has_interfaces).set_interface_comp()
 
     def __new__(cls):
         self = super().__new__(cls)
@@ -158,7 +158,7 @@ class NAND(Component):
         self._set_interface_comp()
 
     def _set_interface_comp(self):
-        self.get_trait(has_interfaces).set_interface_comp(self)
+        self.get_trait(has_interfaces).set_interface_comp()
 
     def __new__(cls, *args, **kwargs):
         self = super().__new__(cls)
@@ -233,14 +233,14 @@ class CD4011(Component):
     def _setup_nands(self):
         self.nands = times(4, lambda: NAND(input_cnt=2))
         for n in self.nands:
-            n.add_trait(has_symmetric_footprint_pinmap(n))
+            n.add_trait(has_symmetric_footprint_pinmap())
 
     def _setup_inouts(self):
         nand_inout_interfaces = [i for n in self.nands for i in get_all_interfaces([n.output, *n.inputs])]
         self.in_outs = times(len(nand_inout_interfaces), Electrical)
 
     def _setup_internal_connections(self):
-        self.get_trait(has_interfaces).set_interface_comp(self)
+        self.get_trait(has_interfaces).set_interface_comp()
 
         self.connection_map = {}
 

--- a/faebryk/library/traits/component.py
+++ b/faebryk/library/traits/component.py
@@ -22,21 +22,13 @@ class has_interfaces(ComponentTrait):
     def get_interfaces(self) -> list[Interface]:
         raise NotImplementedError()
 
-    def set_interface_comp(self, comp):
+    def set_interface_comp(self):
         for i in self.get_interfaces():
-            i.set_component(comp)
+            i.set_component(self.get_obj())
 
 class has_interfaces_list(has_interfaces):
-    def __init__(self, comp: Component) -> None:
-        super().__init__()
-        self.comp = comp
-
     def get_interfaces(self) -> list[Interface]:
-        return self.comp.interfaces
-
-    def set_interface_comp(self, comp=None):
-        assert (comp is None or comp == self.comp) 
-        super().set_interface_comp(self.comp)
+        return self.get_obj().interfaces
 
 class has_defined_interfaces(has_interfaces):
     def __init__(self, interfaces: list[Interface]) -> None:
@@ -77,10 +69,6 @@ class has_defined_footprint_pinmap(has_footprint_pinmap):
         return self.pin_map
 
 class has_symmetric_footprint_pinmap(has_footprint_pinmap):
-    def __init__(self, comp: Component) -> None:
-        super().__init__()
-        self.comp = comp
-    
     def get_pin_map(self):
-        ifs = self.comp.get_trait(has_interfaces).get_interfaces()
+        ifs = self.get_obj().get_trait(has_interfaces).get_interfaces()
         return {k+1:v for k,v in enumerate(ifs)}

--- a/samples/iterative_design_nand.py
+++ b/samples/iterative_design_nand.py
@@ -111,7 +111,7 @@ def run_experiment():
     switch.add_trait(has_defined_footprint(switch_fp))
 
     for symmetric_component in [pull_down_resistor, current_limiting_resistor, switch]:
-        symmetric_component.add_trait(has_symmetric_footprint_pinmap(symmetric_component))
+        symmetric_component.add_trait(has_symmetric_footprint_pinmap())
 
     led.add_trait(has_defined_footprint_pinmap({
         1: led.anode,
@@ -120,16 +120,16 @@ def run_experiment():
 
     #TODO: remove, just compensation for old graph
     battery.add_trait(has_defined_interfaces([battery.power]))
-    battery.get_trait(has_interfaces).set_interface_comp(battery)
-    battery.add_trait(has_symmetric_footprint_pinmap(battery))
+    battery.get_trait(has_interfaces).set_interface_comp()
+    battery.add_trait(has_symmetric_footprint_pinmap())
     logic_virt = Component()
     logic_virt.high = high
     logic_virt.low = low
     logic_virt.add_trait(has_defined_interfaces([logic_virt.high, logic_virt.low]))
-    logic_virt.get_trait(has_interfaces).set_interface_comp(logic_virt)
-    logic_virt.add_trait(has_symmetric_footprint_pinmap(logic_virt))
+    logic_virt.get_trait(has_interfaces).set_interface_comp()
+    logic_virt.add_trait(has_symmetric_footprint_pinmap())
     for n in nand_ic.nands:
-        n.add_trait(has_symmetric_footprint_pinmap(n))
+        n.add_trait(has_symmetric_footprint_pinmap())
 
     # make graph
     components = [

--- a/samples/resistors_and_nand.py
+++ b/samples/resistors_and_nand.py
@@ -53,8 +53,8 @@ def run_experiment():
         r.add_trait(has_defined_footprint(SMDTwoPin(
             SMDTwoPin.Type._0805
         )))
-        r.add_trait(has_symmetric_footprint_pinmap(r))
-    battery.add_trait(has_symmetric_footprint_pinmap(battery))
+        r.add_trait(has_symmetric_footprint_pinmap())
+    battery.add_trait(has_symmetric_footprint_pinmap())
 
 
     comps = [

--- a/test/exporters/netlist/kicad/test_netlist_kicad.py
+++ b/test/exporters/netlist/kicad/test_netlist_kicad.py
@@ -32,8 +32,8 @@ def test_netlist_graph():
         r.add_trait(has_defined_type_description("R"))
         # interfaces
         r.interfaces = [Electrical(), Electrical()]
-        r.add_trait(has_interfaces_list(r))
-        r.get_trait(has_interfaces).set_interface_comp(r)
+        r.add_trait(has_interfaces_list())
+        r.get_trait(has_interfaces).set_interface_comp()
         # footprint
         fp = Footprint()
         fp.add_trait(has_kicad_manual_footprint("Resistor_SMD:R_0805_2012Metric"))
@@ -56,8 +56,8 @@ def test_netlist_graph():
     for i in [gnd, vcc]:
         wrap = Component()
         wrap.interfaces = [i]
-        wrap.add_trait(has_interfaces_list(wrap))
-        wrap.get_trait(has_interfaces).set_interface_comp(wrap)
+        wrap.add_trait(has_interfaces_list())
+        wrap.get_trait(has_interfaces).set_interface_comp()
         wrap.add_trait(has_defined_kicad_ref("+3V3" if i == vcc else "GND"))
         wrap.add_trait(has_defined_footprint_pinmap({1: i}))
         net_wrappers.append(wrap)


### PR DESCRIPTION
# Core: Add backref in traits to their object

# Description

Add backref to faebrykliboject when making trait part of object.
Remove manual backlinks in traits that used those before.

Fixes #49 

## PR type

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist

- [x] My code follows the [coding guidelines](/faebryk/faebryk/blob/main/docs/CODING_GUIDELINES.md) of this project
- [x] My PR title is following the [contribution guidelines](/faebryk/faebryk/blob/main/docs/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

#### Code of Conduct

By submitting this issue, you agree to follow our [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md):

- [x] I agree to follow this project's [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md)
