### PR TITLE
Graph: Handle pin not in map explicitly

### DIFF
--- a/faebryk/exporters/netlist/graph.py
+++ b/faebryk/exporters/netlist/graph.py
@@ -89,9 +89,14 @@ def make_graph_from_components(components):
                         target_pinmap = target_component.get_trait(
                             has_footprint_pinmap
                         ).get_pin_map()
-                        target_pin = list(target_pinmap.items())[
-                            list(target_pinmap.values()).index(target_interface)
-                        ][0]
+                        try:
+                            target_pin = list(target_pinmap.items())[
+                                list(target_pinmap.values()).index(target_interface)
+                            ][0]
+                        except ValueError:
+                            raise FaebrykException(
+                                "Pinmap of component does not contain referenced pin"
+                            )
                         try:
                             target_wrapped = [
                                 i


### PR DESCRIPTION
Throw faebryk exception if pin of target not in target pinmap.

# Graph: Handle pin not in map explicitly

# Description

Cleaner exception for pinmap problems while building graph.

# Checklist

Please read and execute the following:

- [x] My code follows the [coding guidelines](/faebryk/faebryk/blob/main/docs/CODING_GUIDELINES.md) of this project
- [x] My PR title is following the [contribution guidelines](/faebryk/faebryk/blob/main/docs/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I ran [Black](../docs/CONTRIBUTING.md#creating-a-pull-request) to format my code

#### Code of Conduct

By submitting this issue, you agree to follow our [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md):

- [x] I agree to follow this project's [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md)
