### PR TITLE
Build: Seperate faebryk subfolder

### DIFF
--- a/faebryk/exporters/netlist/netlist.py
+++ b/faebryk/exporters/netlist/netlist.py
@@ -196,6 +196,13 @@ def render_graph(t1_netlist):
         bbox=dict(fc="blue"),
         font_color="white",
     )
-    Path("./build/faebryk/").mkdir(parents=True, exist_ok=True)
-    plt.savefig("./build/faebryk/graph.png", format="png", bbox_inches="tight")
+
+    build_folder_path = Path("./build/faebryk/")
+    build_folder_path.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+    graph_filepath = build_folder_path / "graph.png"
+    logger.info("Writing Experiment graph to {}".format(graph_filepath.absolute()))
+    plt.savefig(graph_filepath, format="png", bbox_inches="tight")
     plt.show()

--- a/faebryk/exporters/netlist/netlist.py
+++ b/faebryk/exporters/netlist/netlist.py
@@ -196,6 +196,6 @@ def render_graph(t1_netlist):
         bbox=dict(fc="blue"),
         font_color="white",
     )
-    Path("./build").mkdir(parents=True, exist_ok=True)
-    plt.savefig("./build/graph.png", format="png", bbox_inches="tight")
+    Path("./build/faebryk/").mkdir(parents=True, exist_ok=True)
+    plt.savefig("./build/faebryk/graph.png", format="png", bbox_inches="tight")
     plt.show()

--- a/samples/iterative_design_nand.py
+++ b/samples/iterative_design_nand.py
@@ -152,6 +152,7 @@ def run_experiment():
 
     netlist = from_faebryk_t2_netlist(make_t2_netlist_from_t1(t1_))
 
+    Path("./build/faebryk/").mkdir(parents=True, exist_ok=True)
     path = Path("./build/faebryk.net")
     logger.info("Writing Experiment netlist to {}".format(path.absolute()))
     path.write_text(netlist)

--- a/samples/iterative_design_nand.py
+++ b/samples/iterative_design_nand.py
@@ -152,10 +152,14 @@ def run_experiment():
 
     netlist = from_faebryk_t2_netlist(make_t2_netlist_from_t1(t1_))
 
-    Path("./build/faebryk/").mkdir(parents=True, exist_ok=True)
-    path = Path("./build/faebryk.net")
-    logger.info("Writing Experiment netlist to {}".format(path.absolute()))
-    path.write_text(netlist)
+    build_folder_path = Path("./build/faebryk/")
+    build_folder_path.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+    netlist_filepath = build_folder_path / "faebryk.net"
+    logger.info("Writing Experiment netlist to {}".format(netlist_filepath.absolute()))
+    netlist_filepath.write_text(netlist)
 
     from faebryk.exporters.netlist import render_graph
 

--- a/samples/resistors_and_nand.py
+++ b/samples/resistors_and_nand.py
@@ -73,10 +73,14 @@ def run_experiment():
 
     netlist = from_faebryk_t2_netlist(make_t2_netlist_from_t1(t1_))
 
-    Path("./build/faebryk/").mkdir(parents=True, exist_ok=True)
-    path = Path("./build/faebryk.net")
-    logger.info("Writing Experiment netlist to {}".format(path.absolute()))
-    path.write_text(netlist)
+    build_folder_path = Path("./build/faebryk/")
+    build_folder_path.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+    netlist_filepath = build_folder_path / "faebryk.net"
+    logger.info("Writing Experiment netlist to {}".format(netlist_filepath.absolute()))
+    netlist_filepath.write_text(netlist)
 
     from faebryk.exporters.netlist import render_graph
 

--- a/samples/resistors_and_nand.py
+++ b/samples/resistors_and_nand.py
@@ -73,7 +73,7 @@ def run_experiment():
 
     netlist = from_faebryk_t2_netlist(make_t2_netlist_from_t1(t1_))
 
-
+    Path("./build/faebryk/").mkdir(parents=True, exist_ok=True)
     path = Path("./build/faebryk.net")
     logger.info("Writing Experiment netlist to {}".format(path.absolute()))
     path.write_text(netlist)


### PR DESCRIPTION
# Bugfix: Fix path for graph.png export

# Description

Changed from ./build/graph.png to ./build/faebryk/graph.png
This is also better for external projects that have other things in the build folder (e.g. ./build/kicad/)

# Issue

Fixes #110 

# Checklist

Please read and execute the following:

- [x] My code follows the [coding guidelines](/faebryk/faebryk/blob/main/docs/CODING_GUIDELINES.md) of this project
- [x] My PR title is following the [contribution guidelines](/faebryk/faebryk/blob/main/docs/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I ran [Black](../docs/CONTRIBUTING.md#creating-a-pull-request) to format my code

#### Code of Conduct

By submitting this issue, you agree to follow our [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md):

- [x] I agree to follow this project's [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md)
