### PR TITLE
Deps: Replace sexp_parser with sexpdata

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "test/deps/sexp_parser"]
-	path = test/deps/sexp_parser
-	url = https://github.com/realthunder/sexp_parser.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 networkx
 numpy
 matplotlib
+sexpdata

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,6 +1,5 @@
 # This file is part of the faebryk project
 # SPDX-License-Identifier: MIT
 
-import test.deps
 import test.exporters
 import test.library

--- a/test/deps/__init__.py
+++ b/test/deps/__init__.py
@@ -1,4 +1,0 @@
-# This file is part of the faebryk project
-# SPDX-License-Identifier: MIT
-
-import test.deps.sexp_parser


### PR DESCRIPTION
Deps: Replace sexp_parser with sexpdata

# Description
Replace sexp_parser with a more stable/popular library that has a pip
module. Removing the need for git submodule.

# Checklist

Please read and execute the following:

- [x] My code follows the [coding guidelines](/faebryk/faebryk/blob/main/docs/CODING_GUIDELINES.md) of this project
- [x] My PR title is following the [contribution guidelines](/faebryk/faebryk/blob/main/docs/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I ran [Black](../docs/CONTRIBUTING.md#creating-a-pull-request) to format my code

#### Code of Conduct

By submitting this issue, you agree to follow our [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md):

- [x] I agree to follow this project's [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md)
