### PR TITLE
Bugfix: Netlist: Use kicad ref if available for edge names

### DIFF
--- a/faebryk/exporters/netlist/netlist.py
+++ b/faebryk/exporters/netlist/netlist.py
@@ -171,7 +171,11 @@ def render_graph(t1_netlist):
     intra_edge_dict = dict(
         unique(
             {
-                edge: "{}".format(re.search(r"\[.*\]", edge[0].node["name"]).group())
+                edge: "{}".format(
+                    re.search(r"\[.*\]", edge[0].node["name"]).group()
+                    if edge[0].node["name"].startswith("COMP[")
+                    else edge[0].node["name"]
+                )
                 for edge in intra_comp_edges
             }.items(),
             key=lambda edge: edge[0][0].node,


### PR DESCRIPTION
# Description

Add if statement to allow for names that do not start with `COMP[`

Co-authored-by: IoannisP-ITENG

Fixes #114 

# Checklist

Please read and execute the following:

- [x] My code follows the [coding guidelines](/faebryk/faebryk/blob/main/docs/CODING_GUIDELINES.md) of this project
- [x] My PR title is following the [contribution guidelines](/faebryk/faebryk/blob/main/docs/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I ran [Black](../docs/CONTRIBUTING.md#creating-a-pull-request) to format my code

#### Code of Conduct

By submitting this issue, you agree to follow our [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md):

- [x] I agree to follow this project's [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md)
