### PR TITLE
Replace deprecated function calls in test code

### DIFF
--- a/test/library/test_core.py
+++ b/test/library/test_core.py
@@ -128,18 +128,18 @@ class TestTraits(unittest.TestCase):
         # Test getting trait
         obj.add_trait(trait1_inst)
         self.assertTrue(obj.has_trait(trait1))
-        self.assertEquals(trait1_inst, obj.get_trait(trait1))
-        self.assertEquals(trait1_inst.do(), obj.get_trait(trait1).do())
+        self.assertEqual(trait1_inst, obj.get_trait(trait1))
+        self.assertEqual(trait1_inst.do(), obj.get_trait(trait1).do())
 
         # Test double add
         self.assertRaises(AssertionError, lambda: obj.add_trait(trait1_inst))
 
         # Test replace
         obj.add_trait(cfgtrait1_inst)
-        self.assertEquals(cfgtrait1_inst, obj.get_trait(trait1))
-        self.assertEquals(cfgtrait1_inst.do(), obj.get_trait(trait1).do())
+        self.assertEqual(cfgtrait1_inst, obj.get_trait(trait1))
+        self.assertEqual(cfgtrait1_inst.do(), obj.get_trait(trait1).do())
         obj.add_trait(trait1_inst)
-        self.assertEquals(trait1_inst, obj.get_trait(trait1))
+        self.assertEqual(trait1_inst, obj.get_trait(trait1))
 
         # Test remove
         obj.del_trait(trait2)
@@ -150,14 +150,14 @@ class TestTraits(unittest.TestCase):
         # Test get obj
         self.assertRaises(AssertionError, lambda: trait1_inst.get_obj())
         obj.add_trait(trait1_inst)
-        self.assertEquals(obj.get_trait(trait1).get_obj(), obj)
+        self.assertEqual(obj.get_trait(trait1).get_obj(), obj)
         obj.del_trait(trait1)
         self.assertRaises(AssertionError, lambda: trait1_inst.get_obj())
 
         # Test specific override
         obj.add_trait(impl2_inst)
         obj.add_trait(trait1_inst)
-        self.assertEquals(impl2_inst, obj.get_trait(trait1))
+        self.assertEqual(impl2_inst, obj.get_trait(trait1))
 
         # Test child delete
         obj.del_trait(trait1)


### PR DESCRIPTION
# Fix: Replace deprecated function calls in test code

# Description

assertEquals is deprecated, use assertEqual instead.

# Checklist

Please read and execute the following:

- [x] My code follows the [coding guidelines](/faebryk/faebryk/blob/main/docs/CODING_GUIDELINES.md) of this project
- [ ] My PR title is following the [contribution guidelines](/faebryk/faebryk/blob/main/docs/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I ran [Black](../docs/CONTRIBUTING.md#creating-a-pull-request) to format my code

#### Code of Conduct

By submitting this issue, you agree to follow our [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md):

- [x] I agree to follow this project's [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md)
