### PR TITLE
Core: Add auto-naming objects

### DIFF
--- a/faebryk/exporters/netlist/graph.py
+++ b/faebryk/exporters/netlist/graph.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 import logging
+from itertools import groupby
 from typing import List
 
 from typing_extensions import Self
@@ -21,7 +22,7 @@ def make_t1_netlist_from_graph(comps):
 #   built from directly
 def make_graph_from_components(components):
     from faebryk.library.core import Component
-    from faebryk.library.kicad import has_kicad_footprint, has_kicad_ref
+    from faebryk.library.kicad import has_kicad_footprint
     from faebryk.library.traits.component import (
         has_footprint,
         has_footprint_pinmap,
@@ -32,15 +33,12 @@ def make_graph_from_components(components):
     from faebryk.libs.exceptions import FaebrykException
 
     class wrapper:
-        wrapped_list: List[Self]
-
-        def __init__(self, component: Component) -> None:
+        def __init__(self, component: Component, wrapped_list: List[Self]) -> None:
             self.component = component
             self._setup_non_rec()
+            self.wrapped_list: List[Self]
 
         def _setup_non_rec(self):
-            import random
-
             c = self.component
             self.real = c.has_trait(has_footprint) and c.has_trait(has_footprint_pinmap)
             self.properties = {}
@@ -53,14 +51,11 @@ def make_graph_from_components(components):
                     .get_trait(has_kicad_footprint)
                     .get_kicad_footprint()
                 )
-            if c.has_trait(has_kicad_ref):
-                self.name = c.get_trait(has_kicad_ref).get_ref()
-            else:
-                self.name = "COMP[{}:{}]@{:08X}".format(
-                    type(self.component).__name__,
-                    self.value if self.real else "virt",
-                    int(random.random() * 2**32),
-                )
+            self.name = "{}[{}:{}]".format(
+                self.component.name or "",
+                type(self.component).__name__,
+                self.value if self.real else "virt",
+            )
             self._comp = {}
             self._update_comp()
 
@@ -136,9 +131,18 @@ def make_graph_from_components(components):
     for i in map(get_all_components, components):
         all_components.extend(i)
 
-    wrapped_list = list(map(wrapper, all_components))
-    for i in wrapped_list:
-        i.wrapped_list = wrapped_list
+    wrapped_list = []
+    wrapped_list += [wrapper(comp, wrapped_list) for comp in all_components]
+
+    names = groupby(wrapped_list, key=lambda w: w.name)
+    for name, _objs in names:
+        objs = list(_objs)
+        if len(objs) <= 1:
+            continue
+        for i, obj in enumerate(objs):
+            # TODO deterministic
+            # maybe prefix name of parent instead
+            obj.name += f"@{i}"
 
     logger.debug(
         "Making graph from components:\n\t{}".format(

--- a/faebryk/library/core.py
+++ b/faebryk/library/core.py
@@ -85,7 +85,8 @@ class FaebrykLibObject:
         return self
 
     def __init__(self) -> None:
-        pass
+        if not hasattr(self, "name"):
+            self.name = None
 
     def add_trait(self, trait: TraitImpl) -> None:
         assert isinstance(trait, TraitImpl), ("not a traitimpl:", trait)
@@ -134,6 +135,9 @@ class FaebrykLibObject:
         out = candidates[0][1]
         assert isinstance(out, trait)
         return out
+
+    def set_name(self, name: str) -> None:
+        self.name = name
 
 
 # -----------------------------------------------------------------------------
@@ -186,10 +190,12 @@ class Interface(FaebrykLibObject):
 
                 super().__init__()
 
-            def handle_add(self, intf: Interface):
+            def handle_add(self, name: str, intf: Interface):
                 if self._intf.component is None:
                     return
                 intf.set_component(self._intf.component)
+                intf.set_name(name)
+                return super().handle_add(name, intf)
 
             # TODO this is blocking a nicer implementation of Holder
             # due to not putting into the list, maybe just remove the whole thing
@@ -284,8 +290,10 @@ class Component(FaebrykLibObject):
 
                 super().__init__()
 
-            def handle_add(self, intf: Interface):
+            def handle_add(self, name: str, intf: Interface):
                 intf.set_component(self._comp)
+                intf.set_name(name)
+                return super().handle_add(name, intf)
 
             def add(self, intf: Interface):
                 self.unnamed.append(intf)
@@ -313,6 +321,10 @@ class Component(FaebrykLibObject):
             def add_all(self, cmps: Iterable[Component]):
                 for cmp in cmps:
                     self.add(cmp)
+
+            def handle_add(self, name: str, obj: Component) -> None:
+                obj.set_name(name)
+                return super().handle_add(name, obj)
 
         return _Components
 

--- a/faebryk/libs/util.py
+++ b/faebryk/libs/util.py
@@ -89,7 +89,7 @@ class _wrapper(NotifiesOnPropertyChange, Generic[T]):
         raise NotImplementedError
 
     @abstractmethod
-    def handle_add(self, obj: T):
+    def handle_add(self, name: str, obj: T):
         raise NotImplementedError
 
 
@@ -108,7 +108,7 @@ def Holder(_type: Type[T]) -> Type[_wrapper[T]]:
                 return
             if isinstance(value, self.type):
                 self._list.append(value)
-                self.handle_add(value)
+                self.handle_add(name, value)
                 return
 
             if isinstance(value, Iterable):
@@ -117,8 +117,8 @@ def Holder(_type: Type[T]) -> Type[_wrapper[T]]:
                     return
 
                 self._list += value
-                for instance in value:
-                    self.handle_add(instance)
+                for i, instance in enumerate(value):
+                    self.handle_add(f"{name}[{i}]", instance)
                 return
 
         def get_all(self) -> List[T]:
@@ -142,7 +142,7 @@ def Holder(_type: Type[T]) -> Type[_wrapper[T]]:
 
             return out
 
-        def handle_add(self, obj: T):
+        def handle_add(self, name: str, obj: T) -> None:
             pass
 
     return __wrapper[T]


### PR DESCRIPTION
# Core: Add auto-naming objects

# Description

Derive name of object by its name in the holder.
Remove kicad_ref names.
Remove random suffix in naming.

# Checklist

Please read and execute the following:

- [x] My code follows the [coding guidelines](/faebryk/faebryk/blob/main/docs/CODING_GUIDELINES.md) of this project
- [x] My PR title is following the [contribution guidelines](/faebryk/faebryk/blob/main/docs/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I ran [Black](../docs/CONTRIBUTING.md#creating-a-pull-request) to format my code

#### Code of Conduct

By submitting this issue, you agree to follow our [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md):

- [x] I agree to follow this project's [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md)
