### PR TITLE
Netlist exporter: Add option for extra components in from_faebryk_t2_netlist

### DIFF
--- a/src/faebryk/exporters/netlist/kicad/netlist_kicad.py
+++ b/src/faebryk/exporters/netlist/kicad/netlist_kicad.py
@@ -255,7 +255,7 @@ def _defaulted_comp(ref, value, footprint, tstamp):
 
 
 # Test stuff ------------------------------------------------------------------
-def from_faebryk_t2_netlist(netlist):
+def from_faebryk_t2_netlist(netlist, extra_comps=None):
     tstamp = itertools.count(1)
     net_code = itertools.count(1)
 
@@ -290,7 +290,7 @@ def from_faebryk_t2_netlist(netlist):
                 out_unique.append(x)
         return out_unique
 
-    pre_comps = unique([vertex.component for net in netlist for vertex in net.vertices])
+    pre_comps = unique([vertex.component for net in netlist for vertex in net.vertices] + extra_comps or [])
 
     comps = [
         _defaulted_comp(


### PR DESCRIPTION

# Kicad netlist exporter: Include components not attached to any net in 

# Description

Adds extra components to the netlist that are not connected in any way, such as mechanical holes.

Fixes #150

# Checklist

Please read and execute the following:

- [x] My code follows the [coding guidelines](/faebryk/faebryk/blob/main/docs/CODING_GUIDELINES.md) of this project
- [x] My PR title is following the [contribution guidelines](/faebryk/faebryk/blob/main/docs/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I ran [Black](../docs/CONTRIBUTING.md#creating-a-pull-request) to format my code

#### Code of Conduct

By submitting this issue, you agree to follow our [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md):

- [x] I agree to follow this project's [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md)
