### PR TITLE
Bugfix: Exporter: Handle none extra_comps

### DIFF
--- a/src/faebryk/exporters/netlist/kicad/netlist_kicad.py
+++ b/src/faebryk/exporters/netlist/kicad/netlist_kicad.py
@@ -300,8 +300,8 @@ def from_faebryk_t2_netlist(netlist, extra_comps=None):
         return out_unique
 
     pre_comps = unique(
-        [vertex.component for net in netlist for vertex in net.vertices] + extra_comps
-        or []
+        [vertex.component for net in netlist for vertex in net.vertices]
+        + (extra_comps or [])
     )
 
     comps = [


### PR DESCRIPTION
Bugfix: Exporter: Handle none extra_comps

# Description

Handle "None" case for extra_comps properly (operator precedence was wrong)

Fixes # (issue)

# Checklist

Please read and execute the following:

- [x] My code follows the [coding guidelines](/faebryk/faebryk/blob/main/docs/CODING_GUIDELINES.md) of this project
- [x] My PR title is following the [contribution guidelines](/faebryk/faebryk/blob/main/docs/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I ran [Black](../docs/CONTRIBUTING.md#creating-a-pull-request) to format my code

#### Code of Conduct

By submitting this issue, you agree to follow our [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md):

- [x] I agree to follow this project's [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md)
