### PR TITLE
BugFix: Dependency for easyeda2kicad library

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ repository = "https://github.com/faebryk/faebryk"
 homepage = "https://github.com/faebryk/faebryk"
 
 [tool.poetry.dependencies]
-python = "^3.11,<3.13" # max allowed version by scipy
+python = "^3.11,<3.13"       # max allowed version by scipy
 networkx = "^3.1"
 numpy = "^1.24.3"
 scipy = "^1.11.1"
@@ -31,7 +31,7 @@ sexpdata = "^1.0.1"
 black = "^23.3.0"
 typing-extensions = "^4.6.3"
 easyeda2kicad = "^0.6.3"
-pydantic = "=2.0" #fix for easyeda2kicad 0.6.3
+pydantic = "=1.10.7"         #fix for easyeda2kicad 0.6.3
 
 [tool.poetry.group.dev.dependencies]
 typer = { version = "^0.9.0", extras = ["all"] }
@@ -41,9 +41,7 @@ isort = "^5.6.4"
 ruff = "^0.0.275"
 
 [tool.pytest.ini_options]
-addopts = [
-    "--import-mode=importlib",
-]
+addopts = ["--import-mode=importlib"]
 
 [tool.ruff]
 # Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.


### PR DESCRIPTION
# Description

easyeda2kicad library is incompatible with v2 or higher of pydantic. See: https://github.com/uPesy/easyeda2kicad.py/issues/94

Fixes https://github.com/IoannisP-ITENG/CableTester/issues/8

# Checklist

Please read and execute the following:

- [x] My code follows the [coding guidelines](/faebryk/faebryk/blob/main/docs/CODING_GUIDELINES.md) of this project
- [x] My PR title is following the [contribution guidelines](/faebryk/faebryk/blob/main/docs/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I ran [Black](../docs/CONTRIBUTING.md#creating-a-pull-request) to format my code

#### Code of Conduct

By submitting this issue, you agree to follow our [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md):

- [x] I agree to follow this project's [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md)
