### PR TITLE
Add utilities and classes for BOM generation

### DIFF
--- a/src/faebryk/core/util.py
+++ b/src/faebryk/core/util.py
@@ -36,6 +36,11 @@ def as_scientific(value: SupportsFloat, base=10):
     return mantissa, exponent
 
 
+def round_to_least_signficant_decimal(value: SupportsFloat):
+    f = round(float(value), 8)
+    return str(f).rstrip("0").rstrip(".")
+
+
 def unit_map(
     value: SupportsFloat,
     units: Sequence[str],
@@ -56,7 +61,6 @@ def unit_map(
 
     effective_mantissa = mantissa * (base**exponent_difference)
     round_digits = round(math.log(base, 10) * (1 - exponent_difference))
-    # print(f"{exponent_difference=}, {effective_mantissa=}, {round_digits=}")
 
     idx = available_exponent + start_idx
     rounded_mantissa = round(effective_mantissa, round_digits)
@@ -81,6 +85,18 @@ def get_unit_prefix(value: SupportsFloat, base: int = 1000):
 
 def as_unit(value: SupportsFloat, unit: str, base: int = 1000):
     return get_unit_prefix(value, base=base) + unit
+
+
+def as_unit_with_tolerance(param: Range | Constant, unit: str, base: int = 1000):
+    if isinstance(param, Constant):
+        return as_unit(param.value, unit, base=base) + " ± 0%"
+    (center, delta) = param.as_center_tuple()
+    delta_percent = delta / center * 100
+
+    return (
+        as_unit(center, unit, base=base)
+        + f" ± {round_to_least_signficant_decimal(delta_percent)}%"
+    )
 
 
 def is_type_set_subclasses(type_subclasses: set[type], types: set[type]) -> bool:

--- a/src/faebryk/library/Capacitor.py
+++ b/src/faebryk/library/Capacitor.py
@@ -5,15 +5,15 @@ import logging
 from enum import IntEnum, auto
 
 from faebryk.core.core import Module, Parameter
-from faebryk.core.util import as_unit
+from faebryk.core.util import as_unit, as_unit_with_tolerance
 from faebryk.library.can_attach_to_footprint_symmetrically import (
     can_attach_to_footprint_symmetrically,
 )
 from faebryk.library.can_bridge_defined import can_bridge_defined
 from faebryk.library.Electrical import Electrical
 from faebryk.library.has_designator_prefix_defined import has_designator_prefix_defined
-from faebryk.library.has_simple_value_representation_based_on_param import (
-    has_simple_value_representation_based_on_param,
+from faebryk.library.has_simple_value_representation_based_on_params import (
+    has_simple_value_representation_based_on_params,
 )
 from faebryk.library.TBD import TBD
 from faebryk.libs.util import times
@@ -59,9 +59,15 @@ class Capacitor(Module):
         self.add_trait(can_bridge_defined(*self.IFs.unnamed))
 
         self.add_trait(
-            has_simple_value_representation_based_on_param(
-                self.PARAMs.capacitance,
-                lambda p: as_unit(p, "F"),
+            has_simple_value_representation_based_on_params(
+                (
+                    self.PARAMs.capacitance,
+                    self.PARAMs.rated_voltage,
+                    self.PARAMs.temperature_coefficient,
+                ),
+                lambda ps: f"{as_unit_with_tolerance(ps[0], 'F')} "
+                f"{as_unit(ps[1].max, 'V')} "
+                f"{ps[2].max.name}",
             )
         )
         self.add_trait(can_attach_to_footprint_symmetrically())

--- a/src/faebryk/library/Range.py
+++ b/src/faebryk/library/Range.py
@@ -51,9 +51,24 @@ class Range(Generic[T], Parameter):
     def as_tuple(self) -> tuple[T, T]:
         return (self.min, self.max)
 
+    def as_center_tuple(self) -> tuple[T, T]:
+        return (self.min + self.max) / 2, (self.max - self.min) / 2
+
     @classmethod
-    def from_center(cls, center: T, delta: T) -> "Range":
-        return cls(center - delta, center + delta)
+    def from_center(cls, center: T, delta: T, delta_r: T | None = None) -> "Range":
+        if delta_r is None:
+            delta_r = delta
+        return cls(center - delta, center + delta_r)
+
+    @classmethod
+    def lower_bound(cls, lower) -> "Range":
+        # TODO range should take params as bounds
+        return cls(lower, 1 << 32)
+
+    @classmethod
+    def upper_bound(cls, upper) -> "Range":
+        # TODO range should take params as bounds
+        return cls(0, upper)
 
     def __str__(self) -> str:
         return super().__str__() + f"({self.min} -> {self.max})"

--- a/src/faebryk/library/Resistor.py
+++ b/src/faebryk/library/Resistor.py
@@ -4,22 +4,29 @@
 from math import sqrt
 
 from faebryk.core.core import Module, Parameter
-from faebryk.core.util import as_unit
+from faebryk.core.util import (
+    as_unit,
+    as_unit_with_tolerance,
+)
 from faebryk.library.can_attach_to_footprint_symmetrically import (
     can_attach_to_footprint_symmetrically,
 )
 from faebryk.library.can_bridge_defined import can_bridge_defined
 from faebryk.library.Electrical import Electrical
 from faebryk.library.has_designator_prefix_defined import has_designator_prefix_defined
-from faebryk.library.has_simple_value_representation_based_on_param import (
-    has_simple_value_representation_based_on_param,
+from faebryk.library.has_simple_value_representation_based_on_params import (
+    has_simple_value_representation_based_on_params,
 )
 from faebryk.library.TBD import TBD
 from faebryk.libs.util import times
 
 
 class Resistor(Module):
-    def __init__(self, resistance: Parameter | None = None):
+    def __init__(
+        self,
+        resistance: Parameter | None = None,
+        rated_power: Parameter | None = None,
+    ):
         super().__init__()
 
         class _IFs(super().IFS()):
@@ -30,16 +37,23 @@ class Resistor(Module):
 
         class PARAMS(super().PARAMS()):
             resistance = TBD()
+            rated_power = TBD()
 
         self.PARAMs = PARAMS(self)
         if resistance:
             self.PARAMs.resistance.merge(resistance)
+        if rated_power:
+            self.PARAMs.rated_power.merge(rated_power)
 
         self.add_trait(can_attach_to_footprint_symmetrically())
         self.add_trait(
-            has_simple_value_representation_based_on_param(
-                self.PARAMs.resistance,
-                lambda p: as_unit(p, "Ω"),
+            has_simple_value_representation_based_on_params(
+                (
+                    self.PARAMs.resistance,
+                    self.PARAMs.rated_power,
+                ),
+                lambda ps: f"{as_unit_with_tolerance(ps[0], 'Ω')} "
+                f"{as_unit(ps[1].max, 'W')}",
             )
         )
         self.add_trait(has_designator_prefix_defined("R"))
@@ -103,3 +117,13 @@ class Resistor(Module):
         voltage_drop_V: Parameter, current_A
     ) -> Parameter:
         return voltage_drop_V * current_A
+
+    def set_rated_power_by_voltage_resistance(self, voltage_drop_V: Parameter):
+        self.PARAMs.rated_power.merge(
+            self.get_power_dissipation_by_voltage_resistance(voltage_drop_V)
+        )
+
+    def set_rated_power_by_current_resistance(self, current_A: Parameter):
+        self.PARAMs.rated_power.merge(
+            self.get_power_dissipation_by_current_resistance(current_A)
+        )

--- a/src/faebryk/library/has_simple_value_representation_based_on_params.py
+++ b/src/faebryk/library/has_simple_value_representation_based_on_params.py
@@ -1,0 +1,34 @@
+# This file is part of the faebryk project
+# SPDX-License-Identifier: MIT
+
+from typing import Callable, Sequence, TypeVar
+
+from faebryk.core.core import Parameter
+from faebryk.library.Constant import Constant
+from faebryk.library.has_simple_value_representation import (
+    has_simple_value_representation,
+)
+from faebryk.library.Range import Range
+
+T = TypeVar("T", bound=Sequence[Parameter])
+
+
+class has_simple_value_representation_based_on_params(
+    has_simple_value_representation.impl()
+):
+    def __init__(
+        self, params: T, transformer: Callable[[Sequence[Constant | Range]], str]
+    ) -> None:
+        super().__init__()
+        self.transformer = transformer
+        self.params = params
+
+    def get_value(self) -> str:
+        params_const = tuple(param.get_most_narrow() for param in self.params)
+        assert all(isinstance(p, (Constant, Range)) for p in params_const)
+        return self.transformer(params_const)
+
+    def is_implemented(self):
+        return all(
+            isinstance(p.get_most_narrow(), (Range, Constant)) for p in self.params
+        )

--- a/src/faebryk/libs/app/designators.py
+++ b/src/faebryk/libs/app/designators.py
@@ -18,8 +18,10 @@ from faebryk.library.has_designator_defined import has_designator_defined
 from faebryk.library.has_designator_prefix import has_designator_prefix
 from faebryk.library.has_footprint import has_footprint
 from faebryk.library.has_overriden_name import has_overriden_name
-from faebryk.library.has_overriden_name_defined import has_overriden_name_defined
-from faebryk.libs.util import get_key, groupby
+from faebryk.library.has_overriden_name_defined import (
+    has_overriden_name_defined,
+)
+from faebryk.libs.util import duplicates, get_key, groupby
 
 logger = logging.getLogger(__name__)
 
@@ -50,7 +52,7 @@ def attach_random_designators(graph: Graph):
 
     def _get_first_hole(used: list[int]):
         for i in range(len(used)):
-            if i + 1 != used[i]:
+            if i + 1 not in used:
                 return i + 1
         return len(used) + 1
 
@@ -73,7 +75,8 @@ def attach_random_designators(graph: Graph):
 
     assert len({n.get_trait(has_designator).get_designator() for n in nodes}) == len(
         nodes
-    )
+    ), "Duplicate designators: "
+    f"{duplicates(nodes, lambda n: n.get_trait(has_designator).get_designator())}"
 
 
 def override_names_with_designators(graph: Graph):

--- a/src/faebryk/libs/picker/lcsc.py
+++ b/src/faebryk/libs/picker/lcsc.py
@@ -18,7 +18,7 @@ from faebryk.library.has_defined_descriptive_properties import (
     has_defined_descriptive_properties,
 )
 from faebryk.library.KicadFootprint import KicadFootprint
-from faebryk.libs.picker.picker import Part, Supplier
+from faebryk.libs.picker.picker import Part, PartIdentifier, Supplier
 
 logger = logging.getLogger(__name__)
 
@@ -102,6 +102,19 @@ def get_footprint(partno: str, get_model: bool = True):
     return fp
 
 
+def attach_part_identifier(component: Module, partid: PartIdentifier):
+    if partid.datasheet:
+        has_defined_descriptive_properties.add_properties_to(
+            component, {"Datasheet": partid.datasheet}
+        )
+    has_defined_descriptive_properties.add_properties_to(
+        component, {"Manufacturer": partid.manufacturer}
+    )
+    has_defined_descriptive_properties.add_properties_to(
+        component, {"Partnumber": partid.partno}
+    )
+
+
 def attach_footprint_manually(component: Module, fp: KicadFootprint, partno: str):
     has_defined_descriptive_properties.add_properties_to(component, {"LCSC": partno})
     component.get_trait(can_attach_to_footprint).attach(fp)
@@ -113,9 +126,11 @@ def attach_footprint(component: Module, partno: str, get_model: bool = True):
 
 
 class LCSC(Supplier):
-    def attach(self, module: Module, part: Part):
+    def attach(self, module: Module, part: Part, partid: PartIdentifier = None):
         assert isinstance(part, LCSC_Part)
         attach_footprint(component=module, partno=part.partno)
+        if partid:
+            attach_part_identifier(component=module, partid=partid)
 
 
 class LCSC_Part(Part):

--- a/src/faebryk/libs/picker/picker.py
+++ b/src/faebryk/libs/picker/picker.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 class Supplier(ABC):
     @abstractmethod
-    def attach(self, component: Module, part: "Part"):
+    def attach(self, component: Module, part: "Part", partid: "PartIdentifier" = None):
         ...
 
 
@@ -30,12 +30,20 @@ class Part:
 
 
 @dataclass
+class PartIdentifier:
+    manufacturer: str
+    partno: str
+    datasheet: str
+
+
+@dataclass
 class PickerOption:
     part: Part
     params: dict[str, Parameter] | None = None
     filter: Callable[[Module], bool] | None = None
     pinmap: dict[str, Electrical] | None = None
     info: dict[str, str] | None = None
+    partid: PartIdentifier | None = None
 
 
 def pick_module_by_params(module: Module, options: Iterable[PickerOption]):
@@ -63,7 +71,7 @@ def pick_module_by_params(module: Module, options: Iterable[PickerOption]):
     if option.pinmap:
         module.add_trait(can_attach_to_footprint_via_pinmap(option.pinmap))
 
-    option.part.supplier.attach(module, option.part)
+    option.part.supplier.attach(module, option.part, option.partid)
 
     # Merge params from footprint option
     for k, v in (option.params or {}).items():


### PR DESCRIPTION
# Add utilities and classes for BOM generation

# Description

- Adds an optional PartIdentifier to a Part, which describes the partnumber, manufacturer, and datasheet.
This could be used for BOM exports.
 - Add util function to round float to least significant decimal
 - Add util function to print a Parameter as a unit with tolerance (range
center +- delta)
 - Add has_simple_value_representation_based_on_params trait, which is the
 - same as as_simple_value_representation_based_on_param but with mulitple
parameters and support for ranges
 - Add classmethods for Range to create a Range from a lower/upper bound or
from center.
 - Add rated_power parameter to Resistor and accompanying set functions

Fixes #165, fixes #166

# Checklist

Please read and execute the following:

- [x] My code follows the [coding guidelines](/faebryk/faebryk/blob/main/docs/CODING_GUIDELINES.md) of this project
- [x] My PR title is following the [contribution guidelines](/faebryk/faebryk/blob/main/docs/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I ran [Black](../docs/CONTRIBUTING.md#creating-a-pull-request) to format my code

#### Code of Conduct

By submitting this issue, you agree to follow our [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md):

- [x] I agree to follow this project's [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md)
