### PR TITLE
Part: Add PartIdentifier (mfr, p/n, datasheet)

### DIFF
--- a/src/faebryk/libs/picker/lcsc.py
+++ b/src/faebryk/libs/picker/lcsc.py
@@ -18,7 +18,7 @@ from faebryk.library.has_defined_descriptive_properties import (
     has_defined_descriptive_properties,
 )
 from faebryk.library.KicadFootprint import KicadFootprint
-from faebryk.libs.picker.picker import Part, Supplier
+from faebryk.libs.picker.picker import Part, PartIdentifier, Supplier
 
 logger = logging.getLogger(__name__)
 
@@ -108,6 +108,19 @@ def get_footprint(partno: str, get_model: bool = True):
     return fp
 
 
+def attach_part_identifier(component: Module, partid: PartIdentifier):
+    if partid.datasheet:
+        has_defined_descriptive_properties.add_properties_to(
+            component, {"Datasheet": partid.datasheet}
+        )
+    has_defined_descriptive_properties.add_properties_to(
+        component, {"Manufacturer": partid.manufacturer}
+    )
+    has_defined_descriptive_properties.add_properties_to(
+        component, {"Partnumber": partid.partno}
+    )
+
+
 def attach_footprint_manually(component: Module, fp: KicadFootprint, partno: str):
     has_defined_descriptive_properties.add_properties_to(component, {"LCSC": partno})
     component.get_trait(can_attach_to_footprint).attach(fp)
@@ -119,9 +132,11 @@ def attach_footprint(component: Module, partno: str, get_model: bool = True):
 
 
 class LCSC(Supplier):
-    def attach(self, module: Module, part: Part):
+    def attach(self, module: Module, part: Part, partid: PartIdentifier = None):
         assert isinstance(part, LCSC_Part)
         attach_footprint(component=module, partno=part.partno)
+        if partid:
+            attach_part_identifier(component=module, partid=partid)
 
 
 class LCSC_Part(Part):

--- a/src/faebryk/libs/picker/lcsc.py
+++ b/src/faebryk/libs/picker/lcsc.py
@@ -18,7 +18,11 @@ from faebryk.library.has_defined_descriptive_properties import (
     has_defined_descriptive_properties,
 )
 from faebryk.library.KicadFootprint import KicadFootprint
-from faebryk.libs.picker.picker import Part, PartIdentifier, Supplier
+from faebryk.libs.picker.picker import (
+    Part,
+    PickerOption,
+    Supplier,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -108,19 +112,6 @@ def get_footprint(partno: str, get_model: bool = True):
     return fp
 
 
-def attach_part_identifier(component: Module, partid: PartIdentifier):
-    if partid.datasheet:
-        has_defined_descriptive_properties.add_properties_to(
-            component, {"Datasheet": partid.datasheet}
-        )
-    has_defined_descriptive_properties.add_properties_to(
-        component, {"Manufacturer": partid.manufacturer}
-    )
-    has_defined_descriptive_properties.add_properties_to(
-        component, {"Partnumber": partid.partno}
-    )
-
-
 def attach_footprint_manually(component: Module, fp: KicadFootprint, partno: str):
     has_defined_descriptive_properties.add_properties_to(component, {"LCSC": partno})
     component.get_trait(can_attach_to_footprint).attach(fp)
@@ -132,11 +123,11 @@ def attach_footprint(component: Module, partno: str, get_model: bool = True):
 
 
 class LCSC(Supplier):
-    def attach(self, module: Module, part: Part, partid: PartIdentifier = None):
-        assert isinstance(part, LCSC_Part)
-        attach_footprint(component=module, partno=part.partno)
-        if partid:
-            attach_part_identifier(component=module, partid=partid)
+    def attach(self, module: Module, part: PickerOption):
+        assert isinstance(part.part, LCSC_Part)
+        attach_footprint(component=module, partno=part.part.partno)
+        if part.info is not None:
+            has_defined_descriptive_properties.add_properties_to(module, part.info)
 
 
 class LCSC_Part(Part):

--- a/src/faebryk/libs/picker/picker.py
+++ b/src/faebryk/libs/picker/picker.py
@@ -30,19 +30,19 @@ class Part:
     supplier: Supplier
 
 
+class DescriptiveProperties(StrEnum):
+    manufacturer = "Manufacturer"
+    partno = "Partnumber"
+    datasheet = "Datasheet"
+
+
 @dataclass
 class PickerOption:
     part: Part
     params: dict[str, Parameter] | None = None
     filter: Callable[[Module], bool] | None = None
     pinmap: dict[str, Electrical] | None = None
-    info: dict[str, str] | None = None
-
-
-class DescriptiveProperties(StrEnum):
-    manufacturer = "Manufacturer"
-    partno = "Partnumber"
-    datasheet = "Datasheet"
+    info: dict[str | DescriptiveProperties, str] | None = None
 
 
 class PickError(Exception): ...

--- a/src/faebryk/libs/picker/picker.py
+++ b/src/faebryk/libs/picker/picker.py
@@ -20,7 +20,9 @@ logger = logging.getLogger(__name__)
 
 class Supplier(ABC):
     @abstractmethod
-    def attach(self, component: Module, part: "Part"): ...
+    def attach(
+        self, component: Module, part: "Part", partid: "PartIdentifier | None" = None
+    ): ...
 
 
 @dataclass
@@ -30,12 +32,20 @@ class Part:
 
 
 @dataclass
+class PartIdentifier:
+    manufacturer: str
+    partno: str
+    datasheet: str
+
+
+@dataclass
 class PickerOption:
     part: Part
     params: dict[str, Parameter] | None = None
     filter: Callable[[Module], bool] | None = None
     pinmap: dict[str, Electrical] | None = None
     info: dict[str, str] | None = None
+    partid: PartIdentifier | None = None
 
 
 class PickError(Exception): ...
@@ -85,7 +95,7 @@ def pick_module_by_params(module: Module, options: Iterable[PickerOption]):
     if option.pinmap:
         module.add_trait(can_attach_to_footprint_via_pinmap(option.pinmap))
 
-    option.part.supplier.attach(module, option.part)
+    option.part.supplier.attach(module, option.part, option.partid)
     module.add_trait(has_part_picked_defined(option.part))
 
     # Merge params from footprint option


### PR DESCRIPTION
# Part: Add PartIdentifier (mfr, p/n, datasheet)

# Description

Adds an optional PartIdentifier to a Part, which describes the partnumber, manufacturer, and datasheet.
This could be used for BOM exports.

Fixes #165

# Checklist

Please read and execute the following:

- [x] My code follows the [coding guidelines](/faebryk/faebryk/blob/main/docs/CODING_GUIDELINES.md) of this project
- [x] My PR title is following the [contribution guidelines](/faebryk/faebryk/blob/main/docs/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I ran [Black](../docs/CONTRIBUTING.md#creating-a-pull-request) to format my code

#### Code of Conduct

By submitting this issue, you agree to follow our [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md):

- [x] I agree to follow this project's [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md)
