### PR TITLE
Lib: Diode: Add parameters, move Vrwm to Diode

### DIFF
--- a/src/faebryk/library/Diode.py
+++ b/src/faebryk/library/Diode.py
@@ -19,6 +19,8 @@ class Diode(Module):
             forward_voltage = TBD[float]()
             max_current = TBD[float]()
             current = TBD[float]()
+            reverse_working_voltage = TBD[float]()
+            reverse_leakage_current = TBD[float]()
 
         return _PARAMs
 

--- a/src/faebryk/library/TVS.py
+++ b/src/faebryk/library/TVS.py
@@ -14,6 +14,6 @@ class TVS(Diode):
         super().__init__()
 
         class _PARAMs(Diode.PARAMS()):
-            reverse_working_voltage = TBD()
+            reverse_breakdown_voltage = TBD()
 
         self.PARAMs = _PARAMs(self)


### PR DESCRIPTION
# Lib: Diode: Add parameters, move Vrwm to Diode

# Description

Adds reverse_breakdown_voltage to TVS
Move reverse_working_voltage from TVS to Diode, and add reverse_leakage_current to Diode.

Fixes # (issue)

# Checklist

Please read and execute the following:

- [x] My code follows the [coding guidelines](/faebryk/faebryk/blob/main/docs/CODING_GUIDELINES.md) of this project
- [x] My PR title is following the [contribution guidelines](/faebryk/faebryk/blob/main/docs/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I ran [Black](../docs/CONTRIBUTING.md#creating-a-pull-request) to format my code

#### Code of Conduct

By submitting this issue, you agree to follow our [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md):

- [x] I agree to follow this project's [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md)
