### PR TITLE
Lib: accept all params for simple_value_rep

### DIFF
--- a/src/faebryk/library/Capacitor.py
+++ b/src/faebryk/library/Capacitor.py
@@ -5,7 +5,11 @@ import logging
 from enum import IntEnum, auto
 
 from faebryk.core.core import Module
-from faebryk.core.util import as_unit, as_unit_with_tolerance
+from faebryk.core.util import (
+    as_unit,
+    as_unit_with_tolerance,
+    enum_parameter_representation,
+)
 from faebryk.library.can_attach_to_footprint_symmetrically import (
     can_attach_to_footprint_symmetrically,
 )
@@ -56,9 +60,16 @@ class Capacitor(Module):
                     self.PARAMs.rated_voltage,
                     self.PARAMs.temperature_coefficient,
                 ),
-                lambda ps: f"{as_unit_with_tolerance(ps[0], 'F')} "
-                f"{as_unit(ps[1].max, 'V')} "
-                f"{ps[2].max.value.name}",
+                lambda ps: " ".join(
+                    filter(
+                        None,
+                        [
+                            as_unit_with_tolerance(ps[0], "F"),
+                            as_unit(ps[1], "V"),
+                            enum_parameter_representation(ps[2].get_most_narrow()),
+                        ],
+                    )
+                ),
             )
         )
         self.add_trait(can_attach_to_footprint_symmetrically())

--- a/src/faebryk/library/Resistor.py
+++ b/src/faebryk/library/Resistor.py
@@ -44,8 +44,12 @@ class Resistor(Module):
                     self.PARAMs.resistance,
                     self.PARAMs.rated_power,
                 ),
-                lambda ps: f"{as_unit_with_tolerance(ps[0], 'Ω')} "
-                f"{as_unit(ps[1].max, 'W')}",
+                lambda ps: " ".join(
+                    filter(
+                        None,
+                        [as_unit_with_tolerance(ps[0], "Ω"), as_unit(ps[1], "W")],
+                    )
+                ),
             )
         )
         self.add_trait(has_designator_prefix_defined("R"))

--- a/src/faebryk/library/has_simple_value_representation_based_on_params.py
+++ b/src/faebryk/library/has_simple_value_representation_based_on_params.py
@@ -4,11 +4,9 @@
 from typing import Callable, Sequence
 
 from faebryk.core.core import Parameter
-from faebryk.library.Constant import Constant
 from faebryk.library.has_simple_value_representation import (
     has_simple_value_representation,
 )
-from faebryk.library.Range import Range
 
 
 class has_simple_value_representation_based_on_params(
@@ -17,7 +15,7 @@ class has_simple_value_representation_based_on_params(
     def __init__(
         self,
         params: Sequence[Parameter],
-        transformer: Callable[[Sequence[Constant | Range]], str],
+        transformer: Callable[[Sequence[Parameter]], str],
     ) -> None:
         super().__init__()
         self.transformer = transformer
@@ -25,10 +23,4 @@ class has_simple_value_representation_based_on_params(
 
     def get_value(self) -> str:
         params_const = tuple(param.get_most_narrow() for param in self.params)
-        assert all(isinstance(p, (Constant, Range)) for p in params_const)
         return self.transformer(params_const)
-
-    def is_implemented(self):
-        return all(
-            isinstance(p.get_most_narrow(), (Range, Constant)) for p in self.params
-        )


### PR DESCRIPTION
# Lib: accept all params for simple_value_rep

# Description
Let has_simple_value_representation_based_on_params, as_unit, and as_unit_with_tolerance accept any parameter.

# Checklist

Please read and execute the following:

- [x] My code follows the [coding guidelines](/faebryk/faebryk/blob/main/docs/CODING_GUIDELINES.md) of this project
- [x] My PR title is following the [contribution guidelines](/faebryk/faebryk/blob/main/docs/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I ran Ruff to format my code

#### Code of Conduct

By submitting this issue, you agree to follow our [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md):

- [x] I agree to follow this project's [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md)
