### PR TITLE
Bugfix: LayoutTypeHierarchy should not filter

### DIFF
--- a/src/faebryk/exporters/pcb/layout/typehierarchy.py
+++ b/src/faebryk/exporters/pcb/layout/typehierarchy.py
@@ -10,7 +10,6 @@ from faebryk.core.core import (
 )
 from faebryk.core.util import get_node_direct_children
 from faebryk.exporters.pcb.layout.layout import Layout
-from faebryk.library.has_pcb_position import has_pcb_position
 from faebryk.libs.util import find_or, flatten, groupby
 
 logger = logging.getLogger(__name__)
@@ -31,9 +30,6 @@ class LayoutTypeHierarchy(Layout):
         Tip: Make sure at least one parent of node has an absolute position defined
         """
 
-        # Remove nodes that have a position defined
-        node = tuple(n for n in node if not n.has_trait(has_pcb_position))
-
         # Find the layout for each node and group by matched level
         levels = groupby(
             {
@@ -51,11 +47,6 @@ class LayoutTypeHierarchy(Layout):
             nodes = [n for n, _ in nodes_tuple]
 
             direct_children = flatten(get_node_direct_children(n) for n in nodes)
-
-            # Remove nodes that have a position defined
-            direct_children = [
-                n for n in direct_children if not n.has_trait(has_pcb_position)
-            ]
 
             if level is None:
                 self.apply(*direct_children)


### PR DESCRIPTION
# Bugfix: LayoutTypeHierarchy should not filter

# Description
The hierarchy needs to be applied to all nodes, even if they already
have a position.
The actual end layouts will take care of not overriding the position.

# Checklist

Please read and execute the following:

- [x] My code follows the [coding guidelines](/faebryk/faebryk/blob/main/docs/CODING_GUIDELINES.md) of this project
- [x] My PR title is following the [contribution guidelines](/faebryk/faebryk/blob/main/docs/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I ran [Black](../docs/CONTRIBUTING.md#creating-a-pull-request) to format my code

#### Code of Conduct

By submitting this issue, you agree to follow our [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md):

- [x] I agree to follow this project's [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md)
