### PR TITLE
Bugfix: Library: isinstance for Switch

### DIFF
--- a/src/faebryk/library/Switch.py
+++ b/src/faebryk/library/Switch.py
@@ -1,7 +1,7 @@
 # This file is part of the faebryk project
 # SPDX-License-Identifier: MIT
 
-from typing import TypeVar
+from typing import Generic, TypeGuard, TypeVar
 
 from faebryk.core.core import Module, ModuleInterface
 from faebryk.library.can_attach_to_footprint_symmetrically import (
@@ -16,14 +16,20 @@ from faebryk.libs.util import times
 T = TypeVar("T", bound=ModuleInterface)
 
 
-class _TSwitch(Module):
-    ...
+class _TSwitch(Generic[T], Module):
+    def __init__(self, t: type[T]):
+        super().__init__()
+        self.t = t
+
+    @staticmethod
+    def is_instance(obj: Module, t: type[T]) -> bool:
+        return isinstance(obj, _TSwitch) and issubclass(obj.t, t)
 
 
 def Switch(interface_type: type[T]):
-    class _Switch(_TSwitch):
+    class _Switch(_TSwitch[interface_type]):
         def __init__(self) -> None:
-            super().__init__()
+            super().__init__(interface_type)
 
             self.add_trait(has_designator_prefix_defined("SW"))
             self.add_trait(can_attach_to_footprint_symmetrically())
@@ -33,5 +39,9 @@ def Switch(interface_type: type[T]):
 
             self.IFs = _IFs(self)
             self.add_trait(can_bridge_defined(*self.IFs.unnamed))
+
+        @staticmethod
+        def is_instance(obj: Module) -> "TypeGuard[_Switch]":
+            return _TSwitch.is_instance(obj, interface_type)
 
     return _Switch


### PR DESCRIPTION
Bugfix: Library: isinstance for Switch

# Description
Makes use of `isinstance` possible on Switch

example for electrical interface switch:
```python
F.Switch(Electrical).is_instance(x):
```

Please read and execute the following:

- [x] My code follows the [coding guidelines](/faebryk/faebryk/blob/main/docs/CODING_GUIDELINES.md) of this project
- [x] My PR title is following the [contribution guidelines](/faebryk/faebryk/blob/main/docs/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I ran [Black](../docs/CONTRIBUTING.md#creating-a-pull-request) to format my code

#### Code of Conduct

By submitting this issue, you agree to follow our [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md):

- [x] I agree to follow this project's [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md)
