### PR TITLE
Exporter: Add prj encode/decode; Set netlist path

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -280,6 +280,21 @@ docs = ["ipython", "matplotlib", "numpydoc", "sphinx"]
 tests = ["pytest", "pytest-cov", "pytest-xdist"]
 
 [[package]]
+name = "dataclasses-json"
+version = "0.6.7"
+description = "Easily serialize dataclasses to and from JSON."
+optional = false
+python-versions = "<4.0,>=3.7"
+files = [
+    {file = "dataclasses_json-0.6.7-py3-none-any.whl", hash = "sha256:0dbf33f26c8d5305befd61b39d2b3414e8a407bedc2834dea9b8d642666fb40a"},
+    {file = "dataclasses_json-0.6.7.tar.gz", hash = "sha256:b6b3e528266ea45b9535223bc53ca645f5208833c29229e847b3f26a1cc55fc0"},
+]
+
+[package.dependencies]
+marshmallow = ">=3.18.0,<4.0.0"
+typing-inspect = ">=0.4.0,<1"
+
+[[package]]
 name = "distlib"
 version = "0.3.8"
 description = "Distribution utilities"
@@ -606,6 +621,25 @@ plugins = ["mdit-py-plugins"]
 profiling = ["gprof2dot"]
 rtd = ["jupyter_sphinx", "mdit-py-plugins", "myst-parser", "pyyaml", "sphinx", "sphinx-copybutton", "sphinx-design", "sphinx_book_theme"]
 testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions"]
+
+[[package]]
+name = "marshmallow"
+version = "3.21.3"
+description = "A lightweight library for converting complex datatypes to and from native Python datatypes."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "marshmallow-3.21.3-py3-none-any.whl", hash = "sha256:86ce7fb914aa865001a4b2092c4c2872d13bc347f3d42673272cabfdbad386f1"},
+    {file = "marshmallow-3.21.3.tar.gz", hash = "sha256:4f57c5e050a54d66361e826f94fba213eb10b67b2fdb02c3e0343ce207ba1662"},
+]
+
+[package.dependencies]
+packaging = ">=17.0"
+
+[package.extras]
+dev = ["marshmallow[tests]", "pre-commit (>=3.5,<4.0)", "tox"]
+docs = ["alabaster (==0.7.16)", "autodocsumm (==0.2.12)", "sphinx (==7.3.7)", "sphinx-issues (==4.1.0)", "sphinx-version-warning (==1.1.2)"]
+tests = ["pytest", "pytz", "simplejson"]
 
 [[package]]
 name = "matplotlib"
@@ -1396,6 +1430,21 @@ files = [
 ]
 
 [[package]]
+name = "typing-inspect"
+version = "0.9.0"
+description = "Runtime inspection utilities for typing module."
+optional = false
+python-versions = "*"
+files = [
+    {file = "typing_inspect-0.9.0-py3-none-any.whl", hash = "sha256:9ee6fc59062311ef8547596ab6b955e1b8aa46242d854bfc78f4f6b0eff35f9f"},
+    {file = "typing_inspect-0.9.0.tar.gz", hash = "sha256:b23fc42ff6f6ef6954e4852c1fb512cdd18dbea03134f91f856a95ccc9461f78"},
+]
+
+[package.dependencies]
+mypy-extensions = ">=0.3.0"
+typing-extensions = ">=3.7.4"
+
+[[package]]
 name = "urllib3"
 version = "2.2.2"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -1435,4 +1484,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12,<3.13"
-content-hash = "11dfc7dcdccb012befb4ffc6263ac98e5cda79f4aa843e0cb898f918e8e76f96"
+content-hash = "42c4679041a644320c07ecfd88459c9e5377daebdbfedfd0cdcf58d5714e7b2c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ easyeda2kicad = "^0.8.0"
 shapely = "^2.0.1"
 freetype-py = "^2.4.0"
 kicadcliwrapper = "^1.0.0"
+dataclasses-json = "^0.6.7"
 
 [tool.poetry.group.dev.dependencies]
 typer = { version = "^0.9.0", extras = ["all"] }

--- a/src/faebryk/libs/app/pcb.py
+++ b/src/faebryk/libs/app/pcb.py
@@ -15,7 +15,7 @@ from faebryk.library.has_pcb_position import has_pcb_position
 from faebryk.library.has_pcb_position_defined import has_pcb_position_defined
 from faebryk.library.has_pcb_routing_strategy import has_pcb_routing_strategy
 from faebryk.libs.app.kicad_netlist import write_netlist
-from faebryk.libs.kicad.pcb import PCB, fp_lib_table
+from faebryk.libs.kicad.pcb import PCB, Project, fp_lib_table
 
 logger = logging.getLogger(__name__)
 
@@ -130,6 +130,18 @@ def include_footprints(pcb_path: Path):
 def apply_netlist(pcb_path: Path, netlist_path: Path, netlist_has_changed: bool = True):
     include_footprints(pcb_path)
 
+    # Set netlist path in gui menu
+    prj_path = pcb_path.with_suffix(".kicad_pro")
+    if not prj_path.exists():
+        project = Project()
+    else:
+        project = Project.load(prj_path)
+    project.pcbnew.last_paths.netlist = str(
+        netlist_path.relative_to(pcb_path.parent, walk_up=True)
+    )
+    project.dump(prj_path)
+
+    # Import netlist into pcb
     if netlist_has_changed:
         print(
             "Open the PCB in kicad and import the netlist.\n"

--- a/src/faebryk/libs/kicad/pcb.py
+++ b/src/faebryk/libs/kicad/pcb.py
@@ -2,11 +2,13 @@
 # SPDX-License-Identifier: MIT
 
 import uuid
+from dataclasses import dataclass, field
 from enum import StrEnum
 from pathlib import Path
 from typing import Any, Callable, Generic, List, Tuple, TypeVar
 
 import sexpdata
+from dataclasses_json import CatchAll, Undefined, dataclass_json
 from faebryk.libs.kicad.sexp import prettify_sexp_string
 from sexpdata import Symbol
 
@@ -994,3 +996,37 @@ class fp_lib_table(FileNode):
                 *[[Symbol("lib"), lib.node] for lib in libs],
             ]
         )
+
+
+@dataclass_json(undefined=Undefined.INCLUDE)
+@dataclass
+class Project:
+    @dataclass_json(undefined=Undefined.INCLUDE)
+    @dataclass
+    class _pcbnew:
+        @dataclass_json(undefined=Undefined.INCLUDE)
+        @dataclass
+        class _last_paths:
+            gencad: str = ""
+            idf: str = ""
+            netlist: str = ""
+            plot: str = ""
+            pos_files: str = ""
+            specctra_dsn: str = ""
+            step: str = ""
+            svg: str = ""
+            vrml: str = ""
+            unknown: CatchAll = None
+
+        last_paths: "_last_paths" = field(default_factory=_last_paths)
+        unknown: CatchAll = None
+
+    pcbnew: "_pcbnew" = field(default_factory=_pcbnew)
+    unknown: CatchAll = None
+
+    @classmethod
+    def load(cls, path: Path) -> "Project":
+        return cls.from_json(path.read_text())
+
+    def dump(self, path: Path):
+        return path.write_text(self.to_json(indent=4))

--- a/test/libs/kicad/pcb.py
+++ b/test/libs/kicad/pcb.py
@@ -1,0 +1,21 @@
+# This file is part of the faebryk project
+# SPDX-License-Identifier: MIT
+
+import unittest
+from pathlib import Path
+
+import faebryk.libs.examples.buildutil as B
+from faebryk.libs.kicad.pcb import Project
+
+EXAMPLE_FILES = Path(B.__file__).parent / "resources/example"
+PRJFILE = EXAMPLE_FILES / "example.kicad_pro"
+
+
+class TestPCB(unittest.TestCase):
+    def test_project(self):
+        p = Project.load(PRJFILE)
+        self.assertEqual(p.pcbnew.last_paths.netlist, "../../faebryk/faebryk.net")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Exporter: Add prj encode/decode; Set netlist path

# Description

Add a minimal encode/decode for kicad_prj files.
From here its easy to make it complete if its ever necessary.
Main purpose is to edit the netlist path in the last_paths.
This makes pcbnew point to the netlist per default.

![image](https://github.com/faebryk/faebryk/assets/94004258/c6648528-d478-4155-9524-03684ffe2200)


# Checklist

Please read and execute the following:

- [x] My code follows the [coding guidelines](/faebryk/faebryk/blob/main/docs/CODING_GUIDELINES.md) of this project
- [x] My PR title is following the [contribution guidelines](/faebryk/faebryk/blob/main/docs/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I ran [Black](../docs/CONTRIBUTING.md#creating-a-pull-request) to format my code

#### Code of Conduct

By submitting this issue, you agree to follow our [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md):

- [x] I agree to follow this project's [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md)
