### PR TITLE
Lib: ElectricLogic: add PushPull

### DIFF
--- a/src/faebryk/library/ElectricLogic.py
+++ b/src/faebryk/library/ElectricLogic.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 from abc import abstractmethod
+from enum import Enum, auto
 from typing import Iterable, Self
 
 from faebryk.core.core import (
@@ -22,13 +23,13 @@ from faebryk.library.has_single_electric_reference_defined import (
 )
 from faebryk.library.Logic import Logic
 from faebryk.library.Resistor import Resistor
+from faebryk.library.TBD import TBD
 
 
 class ElectricLogic(Logic):
     class has_pulls(NodeTrait):
         @abstractmethod
-        def get_pulls(self) -> tuple[Resistor | None, Resistor | None]:
-            ...
+        def get_pulls(self) -> tuple[Resistor | None, Resistor | None]: ...
 
     class has_pulls_defined(has_pulls.impl()):
         def __init__(self, up: Resistor | None, down: Resistor | None) -> None:
@@ -41,8 +42,7 @@ class ElectricLogic(Logic):
 
     class can_be_pulled(NodeTrait):
         @abstractmethod
-        def pull(self, up: bool) -> Resistor:
-            ...
+        def pull(self, up: bool) -> Resistor: ...
 
     class can_be_pulled_defined(can_be_pulled.impl()):
         def __init__(self, signal: Electrical, ref: ElectricPower) -> None:
@@ -100,8 +100,18 @@ class ElectricLogic(Logic):
     #
     #        return buffer.NODEs.logic_out
 
+    class PushPull(Enum):
+        PUSH_PULL = auto()
+        OPEN_DRAIN = auto()
+        OPEN_SOURCE = auto()
+
     def __init__(self) -> None:
         super().__init__()
+
+        class PARAMS(Logic.PARAMS()):
+            push_pull: "TBD[ElectricLogic.PushPull]"
+
+        self.PARAMs = PARAMS(self)
 
         class IFS(Logic.NODES()):
             reference = ElectricPower()


### PR DESCRIPTION
# Lib: ElectricLogic: add PushPull

# Description

Adds a push_pull parameter and enum to the ElectricLogic type, so it can be specified if it is push pull, open drain, or open source.

This can be useful to pick parts which have an open-drain output, by checking the push_pull parameter of the output interface.

# Checklist

Please read and execute the following:

- [x] My code follows the [coding guidelines](/faebryk/faebryk/blob/main/docs/CODING_GUIDELINES.md) of this project
- [x] My PR title is following the [contribution guidelines](/faebryk/faebryk/blob/main/docs/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I ran [Black](../docs/CONTRIBUTING.md#creating-a-pull-request) to format my code

#### Code of Conduct

By submitting this issue, you agree to follow our [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md):

- [x] I agree to follow this project's [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md)
