### PR TITLE
SEXP: Support empty enums & Simple unions

### DIFF
--- a/src/faebryk/libs/kicad/fileformats.py
+++ b/src/faebryk/libs/kicad/fileformats.py
@@ -612,14 +612,37 @@ class C_footprint:
             rect = auto()
             roundrect = auto()
 
+        @dataclass
+        class C_options:
+            class E_clearance(StrEnum):
+                outline = auto()
+
+            class E_anchor(StrEnum):
+                rect = auto()
+
+            clearance: E_clearance
+            anchor: E_anchor
+
+        @dataclass
+        class C_drill:
+            class E_shape(StrEnum):
+                circle = ""
+                stadium = "oval"
+
+            shape: E_shape = field(**sexp_field(positional=True))
+            size_x: float = field(**sexp_field(positional=True))
+            size_y: Optional[float] = field(**sexp_field(positional=True), default=None)
+
         name: str = field(**sexp_field(positional=True))
         type: E_type = field(**sexp_field(positional=True))
         shape: E_shape = field(**sexp_field(positional=True))
         at: C_xyr
         size: C_wh
         layers: list[str]
-        drill: Optional[float] = None
+        drill: C_drill | None = None
         remove_unused_layers: bool = False
+        options: Optional[C_options] = None
+        # primitives
 
     @dataclass
     class C_model:

--- a/src/faebryk/libs/kicad/fileformats.py
+++ b/src/faebryk/libs/kicad/fileformats.py
@@ -639,7 +639,7 @@ class C_footprint:
         at: C_xyr
         size: C_wh
         layers: list[str]
-        drill: C_drill | None = None
+        drill: Optional[C_drill] = None
         remove_unused_layers: bool = False
         options: Optional[C_options] = None
         # primitives

--- a/src/faebryk/libs/sexp/dataclass_sexp.py
+++ b/src/faebryk/libs/sexp/dataclass_sexp.py
@@ -2,7 +2,7 @@ import logging
 from dataclasses import Field, dataclass, fields, is_dataclass
 from enum import Enum, StrEnum
 from pathlib import Path
-from types import GenericAlias, UnionType
+from types import UnionType
 from typing import Any, Callable, TypeVar, Union, get_args, get_origin
 
 import sexpdata
@@ -55,7 +55,7 @@ def _convert(val, t):
         if origin is tuple:
             return tuple(_convert(_val, _t) for _val, _t in zip(val, args))
         if origin in (Union, UnionType) and len(args) == 2 and args[1] == type(None):
-            return _convert(val, t.__args__[0]) if val is not None else None
+            return _convert(val, args[0]) if val is not None else None
 
         raise NotImplementedError(f"{origin} not supported")
 
@@ -139,35 +139,24 @@ def _decode(sexp: netlist_type, t: type[T]) -> T:
         name = f.name
         sp = sexp_field.from_field(f)
         if s_name not in key_values:
-            if sp.multidict:
-                value_dict[name] = f.type.__origin__()
+            if sp.multidict and not f.default_factory or f.default:
+                value_dict[name] = get_origin(f.type)()
             # will be automatically filled by factory
             continue
 
-        def _parse_single(kval, t_):
-            logger.debug(f"key_val: {kval}")
-            val: list[list[str | Symbol | int | float | bool]] = kval[1:]
-            assert all(
-                isinstance(v, (str, int, float, Symbol, bool, list)) for v in val
-            )
-
-            return _convert(
-                # val[0] if len(val) == 1 and not isinstance(val[0], list) else val,
-                val,
-                t_,
-            )
-
         values = key_values[s_name]
         if sp.multidict:
-            if isinstance(f.type, GenericAlias) and f.type.__origin__ is list:
-                val_t = f.type.__args__[0]
-                value_dict[name] = [_parse_single(_val, val_t) for _val in values]
-            elif isinstance(f.type, GenericAlias) and f.type.__origin__ is dict:
+            origin = get_origin(f.type)
+            args = get_args(f.type)
+            if origin is list:
+                val_t = args[0]
+                value_dict[name] = [_convert(_val[1:], val_t) for _val in values]
+            elif origin is dict:
                 if not sp.key:
                     raise ValueError(f"Key function required for multidict: {f.name}")
-                key_t = f.type.__args__[0]
-                val_t = f.type.__args__[1]
-                converted_values = [_parse_single(_val, val_t) for _val in values]
+                key_t = args[0]
+                val_t = args[1]
+                converted_values = [_convert(_val[1:], val_t) for _val in values]
                 values_with_key = [(sp.key(_val), _val) for _val in converted_values]
 
                 if not all(isinstance(k, key_t) for k, _ in values_with_key):
@@ -179,10 +168,12 @@ def _decode(sexp: netlist_type, t: type[T]) -> T:
                     raise ValueError(f"Duplicate keys: {d}")
                 value_dict[name] = dict(values_with_key)
             else:
-                raise NotImplementedError(f"Multidict not supported for {f.type}")
+                raise NotImplementedError(
+                    f"Multidict not supported for {origin} in field {f}"
+                )
         else:
             assert len(values) == 1, f"Duplicate key: {name}"
-            value_dict[name] = _parse_single(values[0], f.type)
+            value_dict[name] = _convert(values[0][1:], f.type)
 
     # Positional
     i_f = iter(positional_fields.values())
@@ -201,10 +192,6 @@ def _decode(sexp: netlist_type, t: type[T]) -> T:
 
         value_dict[f.name] = _convert(v, f.type)
         f, v = next(i_f, None), next(i_v, None)
-
-    # for (i1, f), (i2, v) in zip(positional_fields.items(), pos_values.items()):
-    #    name = f.name
-    #    value_dict[name] = _convert(v, f.type)
 
     # Check assertions ----------------------------------------------------
     for f in fs:
@@ -280,10 +267,10 @@ def _encode(t) -> netlist_type:
 
         if sp.multidict:
             if isinstance(val, list):
-                assert f.type.__origin__ is list
+                assert get_origin(f.type) is list
                 _val = val
             elif isinstance(val, dict):
-                assert f.type.__origin__ is dict
+                assert get_origin(f.type) is dict
                 _val = val
                 _val = val.values()
             else:

--- a/test/libs/util.py
+++ b/test/libs/util.py
@@ -1,0 +1,26 @@
+# This file is part of the faebryk project
+# SPDX-License-Identifier: MIT
+
+import unittest
+
+from faebryk.libs.logging import setup_basic_logging
+from faebryk.libs.util import zip_non_locked
+
+
+class TestUtil(unittest.TestCase):
+    def test_zip_non_locked(self):
+        expected = [(1, 4), (2, 5), (3, 6)]
+
+        for val, ref in zip(zip_non_locked([1, 2, 3], [4, 5, 6]), expected):
+            self.assertEqual(val, ref)
+
+        expected = [(1, 4), (2, 5), (2, 6)]
+        for val, ref in zip((it := zip_non_locked([1, 2, 3], [4, 5, 6])), expected):
+            self.assertEqual(val, ref)
+            if val == (2, 5):
+                it.advance(1)
+
+
+if __name__ == "__main__":
+    setup_basic_logging()
+    unittest.main()


### PR DESCRIPTION
# SEXP: Support empty enums & Simple unions

# Description

Kicad has some weird enums with a default being an empty string, which in the sexp becomes just non-existing.
Add support for those cases by skipping the enum field during positional argument parsing if "" is an option.

# Checklist

Please read and execute the following:

- [x] My code follows the [coding guidelines](/faebryk/faebryk/blob/main/docs/CODING_GUIDELINES.md) of this project
- [x] My PR title is following the [contribution guidelines](/faebryk/faebryk/blob/main/docs/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I ran [Black](../docs/CONTRIBUTING.md#creating-a-pull-request) to format my code

#### Code of Conduct

By submitting this issue, you agree to follow our [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md):

- [x] I agree to follow this project's [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md)
